### PR TITLE
Xmltramp tuple indexes [Adds Pypy support]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+.PHONY: test
+
+PYPY := $(shell which pypy 2>/dev/null)
+
+default: test
+
+test:
+	@echo "testing with python"
+	python ./src/pyforce/xmltramp.py
+ifdef PYPY
+	pypy ./src/pyforce/xmltramp.py
+else
+	@echo "pypy not installed... skipping test"
+endif
+
+clean:
+	find . -name '*.pyc' -delete
+	find . -name '__pycache__' -delete

--- a/examples/demo.py
+++ b/examples/demo.py
@@ -21,7 +21,7 @@ class BeatBoxDemo(object):
     def describeGlobal(self):
         print "\ndescribeGlobal"
         dg = svc.describeGlobal()
-        for t in dg[sf.types:]:
+        for t in dg[sf.types,]:
             print str(t)
 
     def describeTabs(self):
@@ -34,29 +34,29 @@ class BeatBoxDemo(object):
         qr = svc.query("select Id, Name from Account")
         print "query size = " + str(qr[sf.size])
 
-        for rec in qr[sf.records:]:
+        for rec in qr[sf.records,]:
             print str(rec[0]) + " : " + str(rec[2]) + " : " + str(rec[3])
 
         if (str(qr[sf.done]) == 'false'):
             print "\nqueryMore"
             qr = svc.queryMore(str(qr[sf.queryLocator]))
-            for rec in qr[sf.records:]:
+            for rec in qr[sf.records,]:
                 print str(rec[0]) + " : " + str(rec[2]) + " : " + str(rec[3])
 
     def upsert(self):
         print "\nupsert"
-        t = { 'type': 'Task', 
-            'ChandlerId__c': '12345', 
-            'subject': 'BeatBoxTest updated', 
+        t = { 'type': 'Task',
+            'ChandlerId__c': '12345',
+            'subject': 'BeatBoxTest updated',
             'ActivityDate' : datetime.date(2006,2,20) }
 
         ur = svc.upsert('ChandlerId__c', t)
         print str(ur[sf.success]) + " -> " + str(ur[sf.id])
 
-        t = {'type': 'Event', 
-            'ChandlerId__c': '67890', 
-            'durationinminutes': 45, 
-            'subject': 'BeatBoxTest', 
+        t = {'type': 'Event',
+            'ChandlerId__c': '67890',
+            'durationinminutes': 45,
+            'subject': 'BeatBoxTest',
             'ActivityDateTime' : datetime.datetime(2006,2,20,13,30,30),
             'IsPrivate': False }
         ur = svc.upsert('ChandlerId__c', t)
@@ -141,22 +141,22 @@ class BeatBoxDemo(object):
     def describeSObjects(self):
         print "\ndescribeSObjects(Account)"
         desc = svc.describeSObjects("Account")
-        for f in desc[sf.fields:]:
+        for f in desc[sf.fields,]:
             print "\t" + str(f[sf.name])
 
         print "\ndescribeSObjects(Lead, Contact)"
         desc = svc.describeSObjects(["Lead", "Contact"])
         for d in desc:
             print str(d[sf.name]) + "\n" + ( "-" * len(str(d[sf.name])))
-            for f in d[sf.fields:]:
+            for f in d[sf.fields,]:
                 print "\t" + str(f[sf.name])
 
     def describeLayout(self):
         print "\ndescribeLayout(Account)"
         desc = svc.describeLayout("Account")
-        for layout in desc[sf.layouts:]:
+        for layout in desc[sf.layouts,]:
             print "sections in detail layout " + str(layout[sf.id])
-            for s in layout[sf.detailLayoutSections:]:
+            for s in layout[sf.detailLayoutSections,]:
                 print "\t" + str(s[sf.heading])
 
 

--- a/examples/export.py
+++ b/examples/export.py
@@ -10,7 +10,7 @@ svc = pyforce.Client()
 def buildSoql(sobjectName):
     dr = svc.describeSObjects(sobjectName)
     soql = ""
-    for f in dr[sf.fields:]:
+    for f in dr[sf.fields,]:
         if len(soql) > 0: soql += ','
         soql += str(f[sf.name])
     return "select " + soql + " from " + sobjectName
@@ -35,7 +35,7 @@ def export(username, password, objectOrSoql):
     printHeaders = 1
     while True:
         if printHeaders: printColumnHeaders(qr); printHeaders = 0
-        for row in qr[sf.records:]:
+        for row in qr[sf.records,]:
             needsComma = False
             for col in row[2:]:
                 if needsComma: print ',',

--- a/examples/soql2atom.py
+++ b/examples/soql2atom.py
@@ -28,7 +28,7 @@ import cgitb
 from xml.sax.xmlreader import AttributesNSImpl
 import datetime
 from urlparse import urlparse
-import os 
+import os
 import base64
 import string
 
@@ -73,15 +73,15 @@ def soql2atom(loginResult, soql, title):
     x.writeStringElement(atom_ns, "name", str(userInfo.userFullName))
     x.endElement()
     x.characters("\n")
-    rel = AttributesNSImpl( {(None, "rel"): "self", (None, "href") : thisUrl}, 
+    rel = AttributesNSImpl( {(None, "rel"): "self", (None, "href") : thisUrl},
                             {(None, "rel"): "rel",  (None, "href"): "href"})
     x.startElement(atom_ns, "link", rel)
     x.endElement()
-    x.writeStringElement(atom_ns, "updated", datetime.datetime.utcnow().isoformat() +"Z") 
+    x.writeStringElement(atom_ns, "updated", datetime.datetime.utcnow().isoformat() +"Z")
     x.writeStringElement(atom_ns, "id", thisUrl + "&userid=" + str(loginResult[pyforce._tPartnerNS.userId]))
     x.characters("\n")
     type = AttributesNSImpl({(None, u"type") : "html"}, {(None, u"type") : u"type" })
-    for row in qr[sf.records:]:
+    for row in qr[sf.records,]:
         x.startElement(atom_ns, "entry")
         desc = ""
         x.writeStringElement(atom_ns, "title", str(row[2]))
@@ -105,7 +105,7 @@ def soql2atom(loginResult, soql, title):
     print x.endDocument()
 
 def writeLink(x, namespace, localname, rel, type, href):
-    rel = AttributesNSImpl( {(None, "rel"): rel,   (None, "href"): href,   (None, "type"): type }, 
+    rel = AttributesNSImpl( {(None, "rel"): rel,   (None, "href"): href,   (None, "type"): type },
                             {(None, "rel"): "rel", (None, "href"): "href", (None, "type"): "type"})
     x.startElement(namespace, localname, rel)
     x.endElement()
@@ -129,7 +129,7 @@ else:
     if form.has_key("title"):
         title = form.getvalue("title")
     try:
-        lr = svc.login(username, password)    
+        lr = svc.login(username, password)
         soql2atom(lr, soql, title)
     except pyforce.SoapFaultError, sfe:
         if (sfe.faultCode == 'INVALID_LOGIN'):

--- a/src/pyforce/marshall.py
+++ b/src/pyforce/marshall.py
@@ -58,7 +58,7 @@ register(texttypes, textMarshaller)
 
 
 def multiMarshaller(fieldname, xml, ns):
-    asString = str(xml[getattr(ns, fieldname):][0])
+    asString = str(xml[getattr(ns, fieldname),][0])
     if not asString:
         return []
     return asString.split(';')

--- a/src/pyforce/pyforce.py
+++ b/src/pyforce/pyforce.py
@@ -102,7 +102,7 @@ class Client(BaseClient):
         data['encoding'] = str(res[_tPartnerNS.encoding])
         data['maxBatchSize'] = int(str(res[_tPartnerNS.maxBatchSize]))
         sobjects = list()
-        for r in res[_tPartnerNS.sobjects:]:
+        for r in res[_tPartnerNS.sobjects,]:
             d = dict()
             d['activateable'] = _bool(r[_tPartnerNS.activateable])
             d['createable'] = _bool(r[_tPartnerNS.createable])
@@ -134,7 +134,7 @@ class Client(BaseClient):
             d['updateable'] = _bool(r[_tPartnerNS.updateable])
             sobjects.append(SObject(**d))
         data['sobjects'] = sobjects
-        data['types'] = [str(t) for t in res[_tPartnerNS.types:]]
+        data['types'] = [str(t) for t in res[_tPartnerNS.types,]]
         if not data['types']:
             # BBB for code written against API < 17.0
             data['types'] = [s.name for s in data['sobjects']]
@@ -148,7 +148,7 @@ class Client(BaseClient):
         for r in res:
             d = dict()
             d['activateable'] = _bool(r[_tPartnerNS.activateable])
-            rawreldata = r[_tPartnerNS.ChildRelationships:]
+            rawreldata = r[_tPartnerNS.ChildRelationships,]
             relinfo = [_extractChildRelInfo(cr) for cr in rawreldata]
             d['ChildRelationships'] = relinfo
             d['createable'] = _bool(r[_tPartnerNS.createable])
@@ -165,7 +165,7 @@ class Client(BaseClient):
                 d['feedEnabled'] = _bool(r[_tPartnerNS.feedEnabled])
             except KeyError:
                 pass
-            fields = r[_tPartnerNS.fields:]
+            fields = r[_tPartnerNS.fields,]
             fields = [_extractFieldInfo(f) for f in fields]
             field_map = dict()
             for f in fields:
@@ -179,7 +179,7 @@ class Client(BaseClient):
             d['name'] = str(r[_tPartnerNS.name])
             d['queryable'] = _bool(r[_tPartnerNS.queryable])
             d['recordTypeInfos'] = ([_extractRecordTypeInfo(rti) for rti in
-                                    r[_tPartnerNS.recordTypeInfos:]])
+                                    r[_tPartnerNS.recordTypeInfos,]])
             d['replicateable'] = _bool(r[_tPartnerNS.replicateable])
             d['retrieveable'] = _bool(r[_tPartnerNS.retrieveable])
             d['searchable'] = _bool(r[_tPartnerNS.searchable])
@@ -208,7 +208,7 @@ class Client(BaseClient):
             d['success'] = success = _bool(r[_tPartnerNS.success])
             if not success:
                 d['errors'] = [_extractError(e)
-                               for e in r[_tPartnerNS.errors:]]
+                               for e in r[_tPartnerNS.errors,]]
             else:
                 d['errors'] = list()
         return data
@@ -226,7 +226,7 @@ class Client(BaseClient):
             d['success'] = success = _bool(resu[_tPartnerNS.success])
             if not success:
                 d['errors'] = [_extractError(e)
-                               for e in resu[_tPartnerNS.errors:]]
+                               for e in resu[_tPartnerNS.errors,]]
             else:
                 d['errors'] = list()
                 d['account_id'] = str(resu[_tPartnerNS.accountId])
@@ -272,7 +272,7 @@ class Client(BaseClient):
             d['success'] = success = _bool(resu[_tPartnerNS.success])
             if not success:
                 d['errors'] = [_extractError(e)
-                               for e in resu[_tPartnerNS.errors:]]
+                               for e in resu[_tPartnerNS.errors,]]
             else:
                 d['errors'] = list()
         return data
@@ -308,7 +308,7 @@ class Client(BaseClient):
             d['success'] = success = _bool(r[_tPartnerNS.success])
             if not success:
                 d['errors'] = [_extractError(e)
-                               for e in r[_tPartnerNS.errors:]]
+                               for e in r[_tPartnerNS.errors,]]
             else:
                 d['errors'] = list()
         return data
@@ -337,12 +337,12 @@ class Client(BaseClient):
                 fname = str(field._name[1])
                 if isObject(field):
                     record[fname] = self._extractRecord(
-                        r[field._name:][0], typeDescs
+                        r[field._name,][0], typeDescs
                     )
                 elif isQueryResult(field):
                     record[fname] = QueryRecordSet(
                         records=[self._extractRecord(rec, typeDescs) for rec
-                                 in field[_tPartnerNS.records:]],
+                                 in field[_tPartnerNS.records,]],
                         done=field[_tPartnerNS.done],
                         size=int(str(field[_tPartnerNS.size]))
                     )
@@ -377,13 +377,13 @@ class Client(BaseClient):
         res = BaseClient.query(self, queryString)
         # calculate the union of the sets of record types from each record
         types = reduce(lambda a, b: a | b, [getRecordTypes(r) for r in
-                                        res[_tPartnerNS.records:]], set())
+                                        res[_tPartnerNS.records,]], set())
         new_types = types - set(typeDescs.keys())
         if new_types:
             typeDescs.update(self.queryTypesDescriptions(new_types))
         data = QueryRecordSet(
             records=[self._extractRecord(r, typeDescs) for r in
-                     res[_tPartnerNS.records:]],
+                     res[_tPartnerNS.records,]],
             done=_bool(res[_tPartnerNS.done]),
             size=int(str(res[_tPartnerNS.size])),
             queryLocator=str(res[_tPartnerNS.queryLocator])
@@ -400,13 +400,13 @@ class Client(BaseClient):
         res = BaseClient.queryMore(self, locator)
         # calculate the union of the sets of record types from each record
         types = reduce(lambda a, b: a | b, [getRecordTypes(r) for r in
-                       res[_tPartnerNS.records:]], set())
+                       res[_tPartnerNS.records,]], set())
         new_types = types - set(typeDescs.keys())
         if new_types:
             typeDescs.update(self.queryTypesDescriptions(new_types))
         data = QueryRecordSet(
             records=[self._extractRecord(r, typeDescs) for r in
-                     res[_tPartnerNS.records:]],
+                     res[_tPartnerNS.records,]],
             done=_bool(res[_tPartnerNS.done]),
             size=int(str(res[_tPartnerNS.size])),
             queryLocator=str(res[_tPartnerNS.queryLocator])
@@ -444,7 +444,7 @@ class Client(BaseClient):
             d['success'] = success = _bool(r[_tPartnerNS.success])
             if not success:
                 d['errors'] = [_extractError(e)
-                               for e in r[_tPartnerNS.errors:]]
+                               for e in r[_tPartnerNS.errors,]]
             else:
                 d['errors'] = list()
         return data
@@ -462,7 +462,7 @@ class Client(BaseClient):
             d['success'] = success = _bool(r[_tPartnerNS.success])
             if not success:
                 d['errors'] = [_extractError(e)
-                               for e in r[_tPartnerNS.errors:]]
+                               for e in r[_tPartnerNS.errors,]]
             else:
                 d['errors'] = list()
             d['isCreated'] = d['created'] = _bool(r[_tPartnerNS.created])
@@ -470,7 +470,7 @@ class Client(BaseClient):
 
     def getDeleted(self, sObjectType, start, end):
         res = BaseClient.getDeleted(self, sObjectType, start, end)
-        res = res[_tPartnerNS.deletedRecords:]
+        res = res[_tPartnerNS.deletedRecords,]
         if type(res) not in (TupleType, ListType):
             res = [res]
         data = list()
@@ -487,7 +487,7 @@ class Client(BaseClient):
 
     def getUpdated(self, sObjectType, start, end):
         res = BaseClient.getUpdated(self, sObjectType, start, end)
-        res = res[_tPartnerNS.ids:]
+        res = res[_tPartnerNS.ids,]
         if type(res) not in (TupleType, ListType):
             res = [res]
         return [str(r) for r in res]
@@ -501,7 +501,7 @@ class Client(BaseClient):
         res = BaseClient.describeTabs(self)
         data = list()
         for r in res:
-            tabs = [_extractTab(t) for t in r[_tPartnerNS.tabs:]]
+            tabs = [_extractTab(t) for t in r[_tPartnerNS.tabs,]]
             d = dict(
                 label=str(r[_tPartnerNS.label]),
                 logoUrl=str(r[_tPartnerNS.logoUrl]),
@@ -595,10 +595,10 @@ def _extractFieldInfo(fdata):
     data['length'] = int(str(fdata[_tPartnerNS.length]))
     data['name'] = str(fdata[_tPartnerNS.name])
     data['nameField'] = _bool(fdata[_tPartnerNS.nameField])
-    plValues = fdata[_tPartnerNS.picklistValues:]
+    plValues = fdata[_tPartnerNS.picklistValues,]
     data['picklistValues'] = [_extractPicklistEntry(p) for p in plValues]
     data['precision'] = int(str(fdata[_tPartnerNS.precision]))
-    data['referenceTo'] = [str(r) for r in fdata[_tPartnerNS.referenceTo:]]
+    data['referenceTo'] = [str(r) for r in fdata[_tPartnerNS.referenceTo,]]
     data['restrictedPicklist'] = _bool(fdata[_tPartnerNS.restrictedPicklist])
     data['scale'] = int(str(fdata[_tPartnerNS.scale]))
     data['soapType'] = str(fdata[_tPartnerNS.soapType])
@@ -616,7 +616,7 @@ def _extractFieldInfo(fdata):
 def _extractPicklistEntry(pldata):
     data = dict()
     data['active'] = _bool(pldata[_tPartnerNS.active])
-    data['validFor'] = [str(v) for v in pldata[_tPartnerNS.validFor:]]
+    data['validFor'] = [str(v) for v in pldata[_tPartnerNS.validFor,]]
     data['defaultValue'] = _bool(pldata[_tPartnerNS.defaultValue])
     data['label'] = str(pldata[_tPartnerNS.label])
     data['value'] = str(pldata[_tPartnerNS.value])
@@ -646,7 +646,7 @@ def _extractError(edata):
     data = dict()
     data['statusCode'] = str(edata[_tPartnerNS.statusCode])
     data['message'] = str(edata[_tPartnerNS.message])
-    data['fields'] = [str(f) for f in edata[_tPartnerNS.fields:]]
+    data['fields'] = [str(f) for f in edata[_tPartnerNS.fields,]]
     return data
 
 
@@ -721,5 +721,5 @@ def getRecordTypes(xml):
             elif isQueryResult(field):
                 record_types.update(reduce(lambda x, y: x | y, [
                                     getRecordTypes(r) for r in
-                                    field[_tPartnerNS.records:]]))
+                                    field[_tPartnerNS.records,]]))
     return record_types

--- a/src/pyforce/tests/test_xmlclient.py
+++ b/src/pyforce/tests/test_xmlclient.py
@@ -91,7 +91,7 @@ class TestBeatbox(unittest.TestCase):
             "from Contact where LastName = 'Doe' and FirstName = 'Jane'")
         res = svc.query(query)
         self.assertEqual(int(str(res[partnerns.size])), 1)
-        records = res[partnerns.records:]
+        records = res[partnerns.records,]
         self.assertEqual(
             janeid, str(records[0][pyforce._tSObjectNS.Id]))
 

--- a/src/pyforce/xmltramp.py
+++ b/src/pyforce/xmltramp.py
@@ -83,7 +83,7 @@ class Element(object):
         def arep(a, inprefixes, addns=1):
             out = ''
 
-            for p in self._prefixes.keys():
+            for p in sorted(self._prefixes.keys()):
                 if not p in inprefixes.keys():
                     if addns:
                         out += ' xmlns'
@@ -93,9 +93,8 @@ class Element(object):
                         out += '="'+quote(p, False)+'"'
                     inprefixes[p] = self._prefixes[p]
 
-            for k in a.keys():
+            for k in sorted(a.keys()):
                 out += ' %s="%s"' % (qname(k, inprefixes), quote(a[k], False))
-
             return out
 
         inprefixes = inprefixes or {
@@ -413,15 +412,15 @@ def unittest():
 
     assert repr(d) == '<doc version="2.7182818284590451">...</doc>'
     assert d.__repr__(1) == (
-        '<doc xmlns="http://example.org/bar" xmlns:dc="http://purl.org/dc/eleme'
-        'nts/1.1/" xmlns:bbc="http://example.org/bbc" version="2.71828182845904'
+        '<doc xmlns="http://example.org/bar" xmlns:bbc="http://example.org/bbc"'
+        ' xmlns:dc="http://purl.org/dc/elements/1.1/" version="2.71828182845904'
         '51"><author>John Polk and John Palfrey</author><dc:creator>John Polk</'
         'dc:creator><dc:creator>John Palfrey</dc:creator><bbc:show bbc:station='
         '"4">Buffy</bbc:show></doc>'
     )
     assert d.__repr__(1,1) == (
-        '<doc xmlns="http://example.org/bar" xmlns:dc="http://purl.org/dc/eleme'
-        'nts/1.1/" xmlns:bbc="http://example.org/bbc" version="2.71828182845904'
+        '<doc xmlns="http://example.org/bar" xmlns:bbc="http://example.org/bbc"'
+        ' xmlns:dc="http://purl.org/dc/elements/1.1/" version="2.71828182845904'
         '51">\n\t<author>John Polk and John Palfrey</author>\n\t<dc:creator>Joh'
         'n Polk</dc:creator>\n\t<dc:creator>John Palfrey</dc:creator>\n\t<bbc:s'
         'how bbc:station="4">Buffy</bbc:show>\n</doc>'

--- a/src/pyforce/xmltramp.py
+++ b/src/pyforce/xmltramp.py
@@ -179,20 +179,19 @@ class Element(object):
     def __getitem__(self, n):
         if isinstance(n, int):  # d[1] == d._dir[1]
             return self._dir[n]
-        elif isinstance(n, slice):
-            # # numerical slices
-            if isinstance(n.start, int) or n.start is None:
-                return self._dir[n]
-            else:
-                # d['foo':] == all <foo>s
-                n = n.start
-                if self._dNS and not islst(n):
-                    n = (self._dNS, n)
-                out = []
-                for x in self._dir:
-                    if isinstance(x, Element) and x._name == n:
-                        out.append(x)
-                return out
+        elif isinstance(n, slice) and (
+            isinstance(n.start, int) or n.start is None
+        ):
+            return self._dir[n]
+        elif isinstance(n, tuple) and len(n) == 1:  # d['foo',] == all <foo>s
+            n = n[0]
+            if self._dNS and not islst(n):
+                n = (self._dNS, n)
+            out = []
+            for x in self._dir:
+                if isinstance(x, Element) and x._name == n:
+                    out.append(x)
+            return out
         elif n is None:
             return self._dir
         else:  # d['foo'] == first <foo>
@@ -201,14 +200,14 @@ class Element(object):
             for x in self._dir:
                 if isinstance(x, Element) and x._name == n:
                     return x
-            raise KeyError(n)
+        raise KeyError(n)
 
     def __setitem__(self, n, v):
         if isinstance(n, type(0)):  # d[1]
             self._dir[n] = v
-        elif isinstance(n, slice(0).__class__):
-            # d['foo':] adds a new foo
-            n = n.start
+        elif isinstance(n, tuple) and len(n) == 1:
+            # d['foo',] adds a new foo
+            n = n[0]
             if self._dNS and not islst(n):
                 n = (self._dNS, n)
 
@@ -392,9 +391,9 @@ def unittest():
     assert d[0]._name == "bar"
     assert len(d[:]) == len(d._dir)
     assert len(d[1:]) == len(d._dir) - 1
-    assert len(d['bar':]) == 2
-    d['bar':] = 'baz'
-    assert len(d['bar':]) == 3
+    assert len(d['bar',]) == 2
+    d['bar',] = 'baz'
+    assert len(d['bar',]) == 3
     assert d['bar']._name == 'bar'
 
     d = Element('foo')
@@ -414,18 +413,18 @@ def unittest():
 
     assert repr(d) == '<doc version="2.7182818284590451">...</doc>'
     assert d.__repr__(1) == (
-        '<doc xmlns:bbc="http://example.org/bbc" xmlns:dc="http://purl.org/dc/'
-        'elements/1.1/" xmlns="http://example.org/bar" version="2.718281828459'
-        '0451"><author>John Polk and John Palfrey</author><dc:creator>John Pol'
-        'k</dc:creator><dc:creator>John Palfrey</dc:creator><bbc:show bbc:stat'
-        'ion="4">Buffy</bbc:show></doc>'
+        '<doc xmlns="http://example.org/bar" xmlns:dc="http://purl.org/dc/eleme'
+        'nts/1.1/" xmlns:bbc="http://example.org/bbc" version="2.71828182845904'
+        '51"><author>John Polk and John Palfrey</author><dc:creator>John Polk</'
+        'dc:creator><dc:creator>John Palfrey</dc:creator><bbc:show bbc:station='
+        '"4">Buffy</bbc:show></doc>'
     )
-    assert d.__repr__(1, 1) == (
-        '<doc xmlns:bbc="http://example.org/bbc" xmlns:dc="http://purl.org/dc/'
-        'elements/1.1/" xmlns="http://example.org/bar" version="2.718281828459'
-        '0451">\n\t<author>John Polk and John Palfrey</author>\n\t<dc:creator>'
-        'John Polk</dc:creator>\n\t<dc:creator>John Palfrey</dc:creator>\n\t<b'
-        'bc:show bbc:station="4">Buffy</bbc:show>\n</doc>'
+    assert d.__repr__(1,1) == (
+        '<doc xmlns="http://example.org/bar" xmlns:dc="http://purl.org/dc/eleme'
+        'nts/1.1/" xmlns:bbc="http://example.org/bbc" version="2.71828182845904'
+        '51">\n\t<author>John Polk and John Palfrey</author>\n\t<dc:creator>Joh'
+        'n Polk</dc:creator>\n\t<dc:creator>John Palfrey</dc:creator>\n\t<bbc:s'
+        'how bbc:station="4">Buffy</bbc:show>\n</doc>'
     )
 
     assert repr(parse("<doc xml:lang='en' />")) == '<doc xml:lang="en"></doc>'
@@ -434,12 +433,12 @@ def unittest():
     assert d.author._name == doc.author
     assert str(d[dc.creator]) == "John Polk"
     assert d[dc.creator]._name == dc.creator
-    assert str(d[dc.creator:][1]) == "John Palfrey"
+    assert str(d[dc.creator,][1]) == "John Palfrey"
     d[dc.creator] = "Me!!!"
     assert str(d[dc.creator]) == "Me!!!"
-    assert len(d[dc.creator:]) == 1
-    d[dc.creator:] = "You!!!"
-    assert len(d[dc.creator:]) == 2
+    assert len(d[dc.creator,]) == 1
+    d[dc.creator,] = "You!!!"
+    assert len(d[dc.creator,]) == 2
 
     assert d[bbc.show](bbc.station) == "4"
     d[bbc.show](bbc.station, "5")


### PR DESCRIPTION
This is the patch I referenced in #29 

This patch switches the hack of using string keyed slices to using tuples. The primary incentive here was that the string slices trick is not compatible with the pypy processor. Switching to tuples from slices does little to change the syntax.

A few other, small changes as a result are a Makefile to allow verifying with Python and Pypy in one go as well as sorting the output from xmltramp so that results are predictable.