### PR TITLE
Fix external entities vulnerability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-defusedxml==0.5.0
+defusedxml>=0.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+defusedxml==0.5.0

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(name='pyforce',
     version='1.8.0',
-    install_requires=['defusedxml==0.5.0'],
+    install_requires=['defusedxml>=0.5.0'],
     package_dir={'': 'src'},
     packages=['pyforce'],
     author = "Simon Fell et al.  reluctantly Forked by idbentley",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,8 @@
 from setuptools import setup
 
 setup(name='pyforce',
-    version='1.7.3', # be sure to update the version in pyforce.py too
+    version='1.8.0',
+    install_requires=['defusedxml==0.5.0'],
     package_dir={'': 'src'},
     packages=['pyforce'],
     author = "Simon Fell et al.  reluctantly Forked by idbentley",

--- a/src/pyforce/xmltramp.py
+++ b/src/pyforce/xmltramp.py
@@ -1,8 +1,9 @@
 """xmltramp: Make XML documents easily accessible."""
 
+import defusedxml
 from xml.sax.handler import EntityResolver, DTDHandler, ContentHandler,\
     ErrorHandler
-from xml.sax import make_parser
+from defusedxml.sax import make_parser
 from xml.sax.handler import feature_namespaces
 
 __version__ = "2.18"
@@ -474,6 +475,29 @@ def unittest():
     assert parse(
         '<a xmlns="http://a"><b xmlns="http://b"/></a>'
     ).__repr__(1) == '<a xmlns="http://a"><b xmlns="http://b"></b></a>'
+
+    # This uses internal entities to DoS vulnerable XML parsers
+    evil_xml = """<?xml version="1.0"?>
+        <!DOCTYPE lolz [
+         <!ENTITY lol "lol">
+         <!ELEMENT lolz (#PCDATA)>
+         <!ENTITY lol1 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">
+         <!ENTITY lol2 "&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;">
+         <!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">
+         <!ENTITY lol4 "&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;">
+         <!ENTITY lol5 "&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;">
+         <!ENTITY lol6 "&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;">
+         <!ENTITY lol7 "&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;">
+         <!ENTITY lol8 "&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;">
+         <!ENTITY lol9 "&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;">
+        ]>
+        <lolz>&lol9;</lolz>"""
+    try:
+        assert parse(evil_xml)
+        # It never gets here and instead raises a defusedxml.common.EntitiesForbidden exception
+        assert False
+    except defusedxml.common.EntitiesForbidden:
+        assert True
 
 if __name__ == '__main__':
     unittest()


### PR DESCRIPTION
So in xmltramp it uses a library called xml.sax
https://github.com/alanjcastonguay/pyforce/blob/master/src/pyforce/xmltramp.py#L5

So the xml sax library is one of only 2 libraries vulnerable to XML External Entity Expansion
(https://docs.python.org/2/library/xml.html#xml-vulnerabilities)
If Salesforce gets compromised or has a rogue employee they can probe the network using it and send requests to anything, potentially getting remote code execution. For more information about XXE visit https://en.wikipedia.org/wiki/XML_external_entity_attack